### PR TITLE
Nested messages: replace `.` by `_` in field names

### DIFF
--- a/px4tools/ulog.py
+++ b/px4tools/ulog.py
@@ -580,6 +580,7 @@ def read_ulog(ulog_filename, messages=None):
     d_col_rename = {
         '[': '_',
         ']': '_',
+        '.': '_',
     }
     col_rename_pattern = re.compile(
         r'(' + '|'.join([


### PR DESCRIPTION
Nested messages (such as `position_setpoint` in topic `position_setpoint_triplet`) are not correctly handled.
- `read_ulog` returns DataFrames with columns that contains `.` characters, which prevents accessing these columns using the `dataframe.column_name` syntax
- `concat` drops columns that contain a `.` character, so nested messages are lost.

This PR replaces dots by underscores, which fixes the two issues above.